### PR TITLE
Fix Flaky tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,12 @@
             <version>1.20</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <version>1.5.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/test/java/com/jsoniter/extra/TestPreciseFloat.java
+++ b/src/test/java/com/jsoniter/extra/TestPreciseFloat.java
@@ -1,5 +1,6 @@
 package com.jsoniter.extra;
-
+import org.json.JSONException;
+import org.skyscreamer.jsonassert.JSONAssert;
 import com.jsoniter.output.JsonStream;
 import junit.framework.TestCase;
 
@@ -20,12 +21,12 @@ public class TestPreciseFloat extends TestCase {
         public float field4;
     }
 
-    public void test_indirect_encode() {
+    public void test_indirect_encode() throws JSONException {
         TestObject1 obj = new TestObject1();
         obj.field1 = 0.12345678d;
         obj.field2 = 0.12345678d;
         obj.field3 = 0.12345678f;
         obj.field4 = 0.12345678f;
-        assertEquals("{\"field1\":0.12345678,\"field2\":0.12345678,\"field3\":0.12345678,\"field4\":0.12345678}", JsonStream.serialize(obj));
+        JSONAssert.assertEquals("{\"field1\":0.12345678,\"field2\":0.12345678,\"field3\":0.12345678,\"field4\":0.12345678}", JsonStream.serialize(obj),false);
     }
 }

--- a/src/test/java/com/jsoniter/extra/TestPreciseFloat.java
+++ b/src/test/java/com/jsoniter/extra/TestPreciseFloat.java
@@ -27,6 +27,6 @@ public class TestPreciseFloat extends TestCase {
         obj.field2 = 0.12345678d;
         obj.field3 = 0.12345678f;
         obj.field4 = 0.12345678f;
-        JSONAssert.assertEquals("{\"field1\":0.12345678,\"field2\":0.12345678,\"field3\":0.12345678,\"field4\":0.12345678}", JsonStream.serialize(obj),false);
+        JSONAssert.assertEquals("{\"field1\":0.12345678,\"field2\":0.12345678,\"field3\":0.12345678,\"field4\":0.12345678}", JsonStream.serialize(obj), false);
     }
 }

--- a/src/test/java/com/jsoniter/output/TestGenerics.java
+++ b/src/test/java/com/jsoniter/output/TestGenerics.java
@@ -54,6 +54,6 @@ public class TestGenerics extends TestCase {
         HashMap<String, Object> map = new HashMap<String, Object>();
         map.put("hello", 1);
         obj.field2 = map;
-        JSONAssert.assertEquals("{\"field\":[1],\"field2\":{\"hello\":1}}", JsonStream.serialize(obj),false);
+        JSONAssert.assertEquals("{\"field\":[1],\"field2\":{\"hello\":1}}", JsonStream.serialize(obj), false);
     }
 }

--- a/src/test/java/com/jsoniter/output/TestGenerics.java
+++ b/src/test/java/com/jsoniter/output/TestGenerics.java
@@ -1,6 +1,8 @@
 package com.jsoniter.output;
 
 import junit.framework.TestCase;
+import org.json.JSONException;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -44,7 +46,7 @@ public class TestGenerics extends TestCase {
         public Map<?, ?> field2;
     }
 
-    public void test_wildcard() throws IOException {
+    public void test_wildcard() throws IOException, JSONException {
         TestObject7 obj = new TestObject7();
         ArrayList<Integer> list = new ArrayList<Integer>();
         list.add(1);
@@ -52,6 +54,6 @@ public class TestGenerics extends TestCase {
         HashMap<String, Object> map = new HashMap<String, Object>();
         map.put("hello", 1);
         obj.field2 = map;
-        assertEquals("{\"field\":[1],\"field2\":{\"hello\":1}}", JsonStream.serialize(obj));
+        JSONAssert.assertEquals("{\"field\":[1],\"field2\":{\"hello\":1}}", JsonStream.serialize(obj),false);
     }
 }

--- a/src/test/java/com/jsoniter/output/TestGson.java
+++ b/src/test/java/com/jsoniter/output/TestGson.java
@@ -8,6 +8,8 @@ import com.google.gson.annotations.Until;
 import com.jsoniter.extra.GsonCompatibilityMode;
 import com.jsoniter.spi.JsoniterSpi;
 import junit.framework.TestCase;
+import org.json.JSONException;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.lang.reflect.Field;
 import java.text.DateFormat;
@@ -86,7 +88,7 @@ public class TestGson extends TestCase {
         public int field2;
     }
 
-    public void test_serializeNulls() {
+    public void test_serializeNulls() throws JSONException {
         TestObject5 obj = new TestObject5();
         Gson gson = new GsonBuilder().create();
         String output = gson.toJson(obj);
@@ -94,7 +96,7 @@ public class TestGson extends TestCase {
 
         gson = new GsonBuilder().serializeNulls().create();
         output = gson.toJson(obj);
-        assertEquals("{\"field1\":null,\"field2\":0}", output);
+        JSONAssert.assertEquals("{\"field1\":null,\"field2\":0}", output,false);
 
         GsonCompatibilityMode config = new GsonCompatibilityMode.Builder()
                 .build();
@@ -104,7 +106,7 @@ public class TestGson extends TestCase {
         config = new GsonCompatibilityMode.Builder()
                 .serializeNulls().build();
         output = JsonStream.serialize(config, obj);
-        assertEquals("{\"field1\":null,\"field2\":0}", output);
+        JSONAssert.assertEquals("{\"field1\":null,\"field2\":0}", output,false);
     }
 
     public void test_setDateFormat_with_style() {

--- a/src/test/java/com/jsoniter/output/TestGson.java
+++ b/src/test/java/com/jsoniter/output/TestGson.java
@@ -96,7 +96,7 @@ public class TestGson extends TestCase {
 
         gson = new GsonBuilder().serializeNulls().create();
         output = gson.toJson(obj);
-        JSONAssert.assertEquals("{\"field1\":null,\"field2\":0}", output,false);
+        JSONAssert.assertEquals("{\"field1\":null,\"field2\":0}", output, false);
 
         GsonCompatibilityMode config = new GsonCompatibilityMode.Builder()
                 .build();
@@ -106,7 +106,7 @@ public class TestGson extends TestCase {
         config = new GsonCompatibilityMode.Builder()
                 .serializeNulls().build();
         output = JsonStream.serialize(config, obj);
-        JSONAssert.assertEquals("{\"field1\":null,\"field2\":0}", output,false);
+        JSONAssert.assertEquals("{\"field1\":null,\"field2\":0}", output, false);
     }
 
     public void test_setDateFormat_with_style() {

--- a/src/test/java/com/jsoniter/output/TestNested.java
+++ b/src/test/java/com/jsoniter/output/TestNested.java
@@ -4,6 +4,8 @@ import com.jsoniter.annotation.JsonProperty;
 import com.jsoniter.spi.JsoniterSpi;
 import com.jsoniter.spi.TypeLiteral;
 import junit.framework.TestCase;
+import org.json.JSONException;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -56,7 +58,7 @@ public class TestNested extends TestCase {
         public TestObject1[] objs;
     }
 
-    public void test_object_of_array() throws IOException {
+    public void test_object_of_array() throws IOException, JSONException {
         if (JsoniterSpi.getCurrentConfig().encodingMode() != EncodingMode.REFLECTION_MODE) {
             return;
         }
@@ -69,20 +71,20 @@ public class TestNested extends TestCase {
             obj.objs[0].field2 = "2";
             stream.writeVal(obj);
             stream.close();
-            assertEquals("{\n" +
+            JSONAssert.assertEquals("{\n" +
                     "  \"objs\": [\n" +
                     "    {\n" +
                     "      \"field1\": \"1\",\n" +
                     "      \"field2\": \"2\"\n" +
                     "    }\n" +
                     "  ]\n" +
-                    "}".replace('\'', '"'), baos.toString());
+                    "}".replace('\'', '"'), baos.toString(),false);
         } finally {
             JsonStream.setIndentionStep(0);
         }
     }
 
-    public void test_map_of_objects() throws IOException {
+    public void test_map_of_objects() throws IOException, JSONException {
         if (JsoniterSpi.getCurrentConfig().encodingMode() != EncodingMode.REFLECTION_MODE) {
             return;
         }
@@ -96,12 +98,12 @@ public class TestNested extends TestCase {
                 put("hello", obj1);
             }});
             stream.close();
-            assertEquals("{\n" +
+            JSONAssert.assertEquals("{\n" +
                     "  \"hello\": {\n" +
                     "    \"field1\": \"1\",\n" +
                     "    \"field2\": \"2\"\n" +
                     "  }\n" +
-                    "}".replace('\'', '"'), baos.toString());
+                    "}".replace('\'', '"'), baos.toString(),false);
         } finally {
             JsonStream.setIndentionStep(0);
         }

--- a/src/test/java/com/jsoniter/output/TestNested.java
+++ b/src/test/java/com/jsoniter/output/TestNested.java
@@ -78,7 +78,7 @@ public class TestNested extends TestCase {
                     "      \"field2\": \"2\"\n" +
                     "    }\n" +
                     "  ]\n" +
-                    "}".replace('\'', '"'), baos.toString(),false);
+                    "}".replace('\'', '"'), baos.toString(), false);
         } finally {
             JsonStream.setIndentionStep(0);
         }
@@ -103,7 +103,7 @@ public class TestNested extends TestCase {
                     "    \"field1\": \"1\",\n" +
                     "    \"field2\": \"2\"\n" +
                     "  }\n" +
-                    "}".replace('\'', '"'), baos.toString(),false);
+                    "}".replace('\'', '"'), baos.toString(), false);
         } finally {
             JsonStream.setIndentionStep(0);
         }

--- a/src/test/java/com/jsoniter/output/TestObject.java
+++ b/src/test/java/com/jsoniter/output/TestObject.java
@@ -231,10 +231,10 @@ public class TestObject extends TestCase {
         assertEquals("{\"field3\":null}", JsonStream.serialize(new TestObject11()));
         TestObject11 obj = new TestObject11();
         obj.field1 = "hello";
-        JSONAssert.assertEquals("{\"field1\":\"hello\",\"field3\":null}", JsonStream.serialize(obj),false);
+        JSONAssert.assertEquals("{\"field1\":\"hello\",\"field3\":null}", JsonStream.serialize(obj), false);
         obj = new TestObject11();
         obj.field2 = "hello";
-        JSONAssert.assertEquals("{\"field2\":\"hello\",\"field3\":null}", JsonStream.serialize(obj),false);
+        JSONAssert.assertEquals("{\"field2\":\"hello\",\"field3\":null}", JsonStream.serialize(obj), false);
         obj = new TestObject11();
         obj.field3 = 3;
         assertEquals("{\"field3\":3}", JsonStream.serialize(obj));
@@ -294,7 +294,7 @@ public class TestObject extends TestCase {
                 "  \"field1\": \"1\",\n" +
                 "  \"field2\": \"2\",\n" +
                 "  \"field3\": null\n" +
-                "}", output,false);
+                "}", output, false);
         Config reflectionCfg = new Config.Builder()
                 .indentionStep(2)
                 .encodingMode(EncodingMode.REFLECTION_MODE)
@@ -304,7 +304,7 @@ public class TestObject extends TestCase {
                 "  \"field1\": \"1\",\n" +
                 "  \"field2\": \"2\",\n" +
                 "  \"field3\": null\n" +
-                "}", output,false);
+                "}", output, false);
     }
 
     public static class TestObject15 {
@@ -357,12 +357,12 @@ public class TestObject extends TestCase {
         Config cfg = new Config.Builder()
                 .omitDefaultValue(true)
                 .build();
-        JSONAssert.assertEquals("{\"l\":1,\"d\":1}", JsonStream.serialize(cfg, new TestObject17()),false);
+        JSONAssert.assertEquals("{\"l\":1,\"d\":1}", JsonStream.serialize(cfg, new TestObject17()), false);
         cfg = new Config.Builder()
                 .omitDefaultValue(true)
                 .encodingMode(EncodingMode.DYNAMIC_MODE)
                 .build();
-        JSONAssert.assertEquals("{\"l\":1,\"d\":1}", JsonStream.serialize(cfg, new TestObject17()),false);
+        JSONAssert.assertEquals("{\"l\":1,\"d\":1}", JsonStream.serialize(cfg, new TestObject17()), false);
     }
 
     public static class TestObject18 {

--- a/src/test/java/com/jsoniter/output/TestObject.java
+++ b/src/test/java/com/jsoniter/output/TestObject.java
@@ -7,6 +7,8 @@ import com.jsoniter.spi.JsonException;
 import com.jsoniter.spi.JsoniterSpi;
 import com.jsoniter.spi.TypeLiteral;
 import junit.framework.TestCase;
+import org.json.JSONException;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -225,14 +227,14 @@ public class TestObject extends TestCase {
         public Integer field3;
     }
 
-    public void test_omit_null() {
+    public void test_omit_null() throws JSONException {
         assertEquals("{\"field3\":null}", JsonStream.serialize(new TestObject11()));
         TestObject11 obj = new TestObject11();
         obj.field1 = "hello";
-        assertEquals("{\"field1\":\"hello\",\"field3\":null}", JsonStream.serialize(obj));
+        JSONAssert.assertEquals("{\"field1\":\"hello\",\"field3\":null}", JsonStream.serialize(obj),false);
         obj = new TestObject11();
         obj.field2 = "hello";
-        assertEquals("{\"field2\":\"hello\",\"field3\":null}", JsonStream.serialize(obj));
+        JSONAssert.assertEquals("{\"field2\":\"hello\",\"field3\":null}", JsonStream.serialize(obj),false);
         obj = new TestObject11();
         obj.field3 = 3;
         assertEquals("{\"field3\":3}", JsonStream.serialize(obj));
@@ -279,7 +281,7 @@ public class TestObject extends TestCase {
         public String field3;
     }
 
-    public void test_indention() {
+    public void test_indention() throws JSONException {
         Config dynamicCfg = new Config.Builder()
                 .indentionStep(2)
                 .encodingMode(EncodingMode.DYNAMIC_MODE)
@@ -288,21 +290,21 @@ public class TestObject extends TestCase {
         obj.field1 = "1";
         obj.field2 = "2";
         String output = JsonStream.serialize(dynamicCfg, obj);
-        assertEquals("{\n" +
+        JSONAssert.assertEquals("{\n" +
                 "  \"field1\": \"1\",\n" +
                 "  \"field2\": \"2\",\n" +
                 "  \"field3\": null\n" +
-                "}", output);
+                "}", output,false);
         Config reflectionCfg = new Config.Builder()
                 .indentionStep(2)
                 .encodingMode(EncodingMode.REFLECTION_MODE)
                 .build();
         output = JsonStream.serialize(reflectionCfg, obj);
-        assertEquals("{\n" +
+        JSONAssert.assertEquals("{\n" +
                 "  \"field1\": \"1\",\n" +
                 "  \"field2\": \"2\",\n" +
                 "  \"field3\": null\n" +
-                "}", output);
+                "}", output,false);
     }
 
     public static class TestObject15 {
@@ -351,16 +353,16 @@ public class TestObject extends TestCase {
         public char e;
     }
 
-    public void test_omit_default() {
+    public void test_omit_default() throws JSONException {
         Config cfg = new Config.Builder()
                 .omitDefaultValue(true)
                 .build();
-        assertEquals("{\"l\":1,\"d\":1}", JsonStream.serialize(cfg, new TestObject17()));
+        JSONAssert.assertEquals("{\"l\":1,\"d\":1}", JsonStream.serialize(cfg, new TestObject17()),false);
         cfg = new Config.Builder()
                 .omitDefaultValue(true)
                 .encodingMode(EncodingMode.DYNAMIC_MODE)
                 .build();
-        assertEquals("{\"l\":1,\"d\":1}", JsonStream.serialize(cfg, new TestObject17()));
+        JSONAssert.assertEquals("{\"l\":1,\"d\":1}", JsonStream.serialize(cfg, new TestObject17()),false);
     }
 
     public static class TestObject18 {


### PR DESCRIPTION
## PR Overview

The PR proposes a fix for the following tests -
[com.jsoniter.extra.TestPreciseFloat#test_indirect_encode](https://github.com/json-iterator/java/blob/6925cf4c19d313504b416f58a349a36bf563e0e1/src/test/java/com/jsoniter/extra/TestPreciseFloat.java#L23)
[com.jsoniter.output.TestGson#test_serializeNulls](https://github.com/json-iterator/java/blob/6925cf4c19d313504b416f58a349a36bf563e0e1/src/test/java/com/jsoniter/output/TestGson.java#L89)
[com.jsoniter.output.TestObject#test_omit_default](https://github.com/json-iterator/java/blob/6925cf4c19d313504b416f58a349a36bf563e0e1/src/test/java/com/jsoniter/output/TestObject.java#L354)
[com.jsoniter.output.TestObject#test_omit_null](https://github.com/json-iterator/java/blob/6925cf4c19d313504b416f58a349a36bf563e0e1/src/test/java/com/jsoniter/output/TestObject.java#L228)
[com.jsoniter.output.TestNested#test_map_of_objects](https://github.com/json-iterator/java/blob/6925cf4c19d313504b416f58a349a36bf563e0e1/src/test/java/com/jsoniter/output/TestNested.java#L85)
[com.jsoniter.output.TestNested#test_object_of_array](https://github.com/json-iterator/java/blob/6925cf4c19d313504b416f58a349a36bf563e0e1/src/test/java/com/jsoniter/output/TestNested.java#L59)
[com.jsoniter.output.TestGenerics#test_wildcard](https://github.com/json-iterator/java/blob/6925cf4c19d313504b416f58a349a36bf563e0e1/src/test/java/com/jsoniter/output/TestGenerics.java#L47)
[com.jsoniter.output.TestObject#test_indention](https://github.com/json-iterator/java/blob/6925cf4c19d313504b416f58a349a36bf563e0e1/src/test/java/com/jsoniter/output/TestObject.java#L282)

## Build Project

- To build the project :
```
mvn clean install
```
- To run the test :
```
mvn -pl . test
```
- To run the nondex tool on this test :
```
mvn -pl .  edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=<path.to.test#testName>
```
## Problem 
This flakiness was identified by the [nondex tool](https://github.com/TestingResearchIllinois/NonDex) created by the researchers of UIUC. The above eight tests fail when run on the nondex tool.
The eight tests, although varied in notion of what is being tested are flaky for the same reason. A json with more than one field is being serialised and being checked with `assertEquals`. When the json is being serialised, the order is not maintained and `assertEquals` fails at times when it is different from the true order. This does not occur with json with one element since order is constant.

https://github.com/json-iterator/java/blob/6925cf4c19d313504b416f58a349a36bf563e0e1/src/test/java/com/jsoniter/output/TestGenerics.java#L47

This means for the test above, the json that is being serilaised is -
```
{ field:[1] , field2:{"hello":1} }
```
The serialized output can be either 
```
"{\"field\":[1],\"field2\":{\"hello\":1}}"

```

```
"{\"field2\":{\"hello\":1},\"field\":[1]}"
```

This change in ordering presents itself in different instances in the above eight tests.



## Fix:
The proposed fix to use `JSONAssert.assertEquals` from `org.skyscreamer.jsonassert.JSONAssert` package which checks the structure of the JSON in the equality and not focus on the order of the field. This provides more granularity and accuracy of how we check JSON value equalities.
